### PR TITLE
Upgrade SDL3 Library

### DIFF
--- a/lib/src/library.dart
+++ b/lib/src/library.dart
@@ -15,9 +15,9 @@ class SdlLibrary {
   static Timer? _eventLoop;
 
   static final _arena = Arena();
-  static final _eventPointer = _arena<sdl.SdlEvent>();
+  static final Pointer<sdl.SdlEvent> _eventPointer = _arena<sdl.SdlEvent>();
 
-  static void _update(_) {
+  static void _update(dynamic _) {
     sdl.sdlPumpEvents();
     sdl.sdlUpdateGamepads();
     while (true) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,9 +7,9 @@ environment:
   sdk: ^3.5.0
 
 dependencies:
-  sdl3: ^0.1.44
+  sdl3: ^2.3.6
   ffi: ^2.1.3
   collection: ^1.18.0
 
 dev_dependencies:
-  very_good_analysis: ^6.0.0
+  very_good_analysis: ^10.0.0


### PR DESCRIPTION
The version of SDL3 this project is pinned to is extremely old, and for projects which want to use other SDL3 APIs along with with the gamepad library, many newer functions will not be accessible

Additionally, very_good_analysis was updated